### PR TITLE
fix failed dl system

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -232,6 +232,13 @@ func NewFixFileDownloader(url string, storePath string, resultLines []string) ([
 	//err := errors.New("")
 
 	if err != nil {
+		if strings.Contains(err.Error(), "Content-Length") {
+			err = DownloadFile(storePath, fileUrl)
+		}
+		if err == nil {
+			log.AsmrLog.Info("文件下载成功: ", zap.String("info", storePath))
+			return resultLines, nil
+		}
 		log.AsmrLog.Error(err.Error())
 		//fmt.Printf("文件: %s下载失败: %s\n", fileName, fileUrl)
 		log.AsmrLog.Error(fmt.Sprintf("文件: %s下载失败: %s", storePath, err.Error()))
@@ -329,10 +336,6 @@ func CheckIfNeedFixBrokenDownloadFile() bool {
 			resultLine = append(resultLine, string(line))
 		}
 	}
-	if len(resultLine) == 0 {
-		return false
-	}
-	return true
 	return len(resultLine) != 0
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -150,7 +150,7 @@ func NewFileDownloader(url string, path string, filename string) func() error {
 			//fmt.Printf("文件: %s下载失败: %s\n", fileName, fileUrl)
 			log.AsmrLog.Error(fmt.Sprintf("文件: %s下载失败: %s", fileName, err.Error()))
 			//记录失败文件  时间, 文件路径，文件url
-			logStr := GetCurrentDateTime() + "," + storePath + "," + fileUrl + "\n"
+			logStr := GetCurrentDateTime() + "|" + storePath + "|" + fileUrl + "\n"
 			write := bufio.NewWriter(FailedDownloadFile)
 			_, _ = write.WriteString(logStr)
 			//Flush将缓存的文件真正写入到文件中
@@ -210,7 +210,7 @@ func NewFixFileDownloader(url string, storePath string, resultLines []string) ([
 		//fmt.Printf("文件: %s下载失败: %s\n", fileName, fileUrl)
 		log.AsmrLog.Error(fmt.Sprintf("文件: %s下载失败: %s", storePath, err.Error()))
 		//记录失败文件  时间, 文件路径，文件url
-		logStr := GetCurrentDateTime() + "," + storePath + "," + fileUrl
+		logStr := GetCurrentDateTime() + "|" + storePath + "|" + fileUrl
 		resultLines = append(resultLines, logStr)
 	} else {
 		log.AsmrLog.Info("文件下载成功: ", zap.String("info", storePath))
@@ -255,7 +255,7 @@ func FixBrokenDownloadFile(maxRetry int) {
 	for i := 0; i < maxRetry; i++ {
 		for index, brokenLine := range resultLine {
 			log.AsmrLog.Info(fmt.Sprintf("index: %d,line: %s", index, brokenLine))
-			fileInfos := strings.Split(brokenLine, ",")
+			fileInfos := strings.Split(brokenLine, "|")
 			downloader, _ := NewFixFileDownloader(fileInfos[2], fileInfos[1], resultContainer)
 			resultContainer = downloader
 		}


### PR DESCRIPTION
RT, 在我的使用过程中发现有些源文件的名字包含 `,` 这一字符，这在fix的流程中里的split会引起url parse错误并导致fix永远无法完成。